### PR TITLE
fix: Add SeenMessageStore deduplication to RelayCoordinator

### DIFF
--- a/lib/data/services/ble_message_handler_facade.dart
+++ b/lib/data/services/ble_message_handler_facade.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 import 'package:logging/logging.dart';
 import '../../core/interfaces/i_ble_message_handler_facade.dart';
+import '../../core/interfaces/i_seen_message_store.dart';
 import '../../core/models/protocol_message.dart';
 import '../../core/models/mesh_relay_models.dart';
 import '../../core/messaging/mesh_relay_engine.dart';
@@ -55,6 +56,12 @@ class BLEMessageHandlerFacade implements IBLEMessageHandlerFacade {
   Future<void> initializeRelaySystem({required String currentNodeId}) async {
     _ensureInitialized();
     await _relayCoordinator.initializeRelaySystem(currentNodeId: currentNodeId);
+  }
+
+  /// Sets the SeenMessageStore for relay deduplication
+  void setSeenMessageStore(ISeenMessageStore seenMessageStore) {
+    _ensureInitialized();
+    _relayCoordinator.setSeenMessageStore(seenMessageStore);
   }
 
   /// Gets available next hop devices for relay


### PR DESCRIPTION
Fixes critical mesh relay bug where duplicate messages were not suppressed, causing loops and traffic amplification within the 3-hop relay window.

Changes:
- Inject ISeenMessageStore into RelayCoordinator for duplicate detection
- Update shouldAttemptRelay() to check hasDelivered() before allowing relay
- Mark messages as delivered in handleMeshRelay() after relay decision
- Add setSeenMessageStore() setter to RelayCoordinator and BLEMessageHandlerFacade
- Add comprehensive tests for duplicate detection and relay marking
- Fix defensive substring logging for short message IDs

Bug: When same relay message received twice within 3-hop window:
  Device A receives msg X → forwards to Device B
  Device C also forwards msg X to Device A
  Result: Device A forwards msg X again → loop/amplification

Fix: Track delivered messages in SeenMessageStore (5-min window)
  Device A receives msg X → marks as delivered → forwards to Device B
  Device C forwards msg X to Device A → marked as delivered → rejected
  Result: Single forward, no loops

Testing: All 23 relay coordinator tests passing

🤖 Generated with Claude Code