### PR TITLE
fix: Auto-inject SeenMessageStore in BLEMessageHandlerFacade

### DIFF
--- a/lib/core/interfaces/i_ble_message_handler_facade.dart
+++ b/lib/core/interfaces/i_ble_message_handler_facade.dart
@@ -1,4 +1,5 @@
 import 'dart:typed_data';
+import '../../core/interfaces/i_seen_message_store.dart';
 import '../../core/models/protocol_message.dart';
 import '../../core/models/mesh_relay_models.dart';
 import '../../core/messaging/mesh_relay_engine.dart';
@@ -21,7 +22,14 @@ abstract interface class IBLEMessageHandlerFacade {
   /// Initializes relay system with dependencies
   ///
   /// Called once at app startup after all services are initialized
+  /// Automatically injects ISeenMessageStore for duplicate detection
   Future<void> initializeRelaySystem({required String currentNodeId});
+
+  /// Sets the SeenMessageStore for relay deduplication
+  ///
+  /// **Note**: Normally called automatically by initializeRelaySystem() during production startup.
+  /// Provided as public method for test overrides.
+  void setSeenMessageStore(ISeenMessageStore seenMessageStore);
 
   /// Gets available next hop devices for relay
   List<String> getAvailableNextHops();


### PR DESCRIPTION
**Problem**: SeenMessageStore was never injected in production, leaving RelayCoordinator._seenMessageStore as null. This meant duplicate relay detection never worked, allowing message loop amplification.

Root cause: setSeenMessageStore() method existed but was never called because it wasn't on the public interface and had no call site.

**Solution**:
1. Add setSeenMessageStore() to public interface IBLEMessageHandlerFacade
2. Auto-inject from DI container in initializeRelaySystem()
3. Added logging for injection success/failure

**Changes**:
- IBLEMessageHandlerFacade: Added setSeenMessageStore() method + import
- BLEMessageHandlerFacade: Auto-inject from GetIt during init
- All 76+ relay tests pass

This ensures duplicate detection works in production while maintaining backward compatibility for test overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)