### PR TITLE
fix: prevent downgrade-guard poisoning from unauthenticated sender identities

### DIFF
--- a/lib/data/services/inbound_text_processor.dart
+++ b/lib/data/services/inbound_text_processor.dart
@@ -142,8 +142,6 @@ class InboundTextProcessor {
         await _resolveSenderKeyForSignature(declaredSenderId);
     final versionPeerKey = _versionPeerKey(
       signatureSenderKey: resolvedDeclaredSenderForSignature,
-      declaredSenderId: declaredSenderId,
-      transportSenderId: senderPublicKey,
     );
     if (_shouldRejectLegacyDowngrade(
       messageVersion: protocolMessage.version,
@@ -159,7 +157,7 @@ class InboundTextProcessor {
               ? resolvedSenderForDecrypt
               : resolvedOriginalSenderForDecrypt);
     String? decryptKeyUsed = decryptKey;
-    var isV2Authenticated = protocolMessage.version < 2;
+    var isV2IdentityAuthenticated = protocolMessage.version < 2;
 
     if (protocolMessage.isEncrypted) {
       if (_shouldRequireV2Signature(
@@ -418,12 +416,12 @@ class InboundTextProcessor {
       } else {
         _logger.info('✅ Real signature verified');
       }
-      if (protocolMessage.version >= 2) {
-        isV2Authenticated = true;
+      if (protocolMessage.version >= 2 && !protocolMessage.useEphemeralSigning) {
+        isV2IdentityAuthenticated = true;
       }
     }
 
-    if (protocolMessage.version < 2 || isV2Authenticated) {
+    if (protocolMessage.version < 2 || isV2IdentityAuthenticated) {
       _trackPeerVersionFloor(
         peerKey: versionPeerKey,
         messageVersion: protocolMessage.version,
@@ -453,16 +451,11 @@ class InboundTextProcessor {
 
   String _versionPeerKey({
     required String? signatureSenderKey,
-    required String? declaredSenderId,
-    required String? transportSenderId,
   }) {
     if (signatureSenderKey != null && signatureSenderKey.isNotEmpty) {
       return signatureSenderKey;
     }
-    if (declaredSenderId != null && declaredSenderId.isNotEmpty) {
-      return declaredSenderId;
-    }
-    return transportSenderId ?? '';
+    return '';
   }
 
   bool _shouldRejectLegacyDowngrade({
@@ -556,7 +549,7 @@ class InboundTextProcessor {
   }
 
   Future<String?> _resolveSenderKeyForSignature(String? candidateKey) async {
-    if (candidateKey == null || candidateKey.isEmpty) return candidateKey;
+    if (candidateKey == null || candidateKey.isEmpty) return null;
     try {
       final contact = await _contactRepository.getContactByAnyId(candidateKey);
       if (contact != null) {
@@ -583,7 +576,7 @@ class InboundTextProcessor {
         'Signature sender resolution failed for ${_safeTruncate(candidateKey)}: $e',
       );
     }
-    return candidateKey;
+    return null;
   }
 
   bool _isLegacyMode(CryptoMode mode) {

--- a/lib/data/services/protocol_message_handler.dart
+++ b/lib/data/services/protocol_message_handler.dart
@@ -241,8 +241,6 @@ class ProtocolMessageHandler implements IProtocolMessageHandler {
           : fromNodeId;
       final versionPeerKey = _versionPeerKey(
         signatureSenderKey: resolvedSignatureSenderKey,
-        declaredSenderId: declaredSenderId,
-        transportSenderId: fromNodeId,
       );
       if (_shouldRejectLegacyDowngrade(
         messageVersion: message.version,
@@ -280,7 +278,7 @@ class ProtocolMessageHandler implements IProtocolMessageHandler {
 
       // Decrypt if needed
       String decryptedContent = content;
-      var isV2Authenticated = message.version < 2;
+      var isV2IdentityAuthenticated = message.version < 2;
       if (message.isEncrypted && decryptionPeerId.isNotEmpty) {
         if (_shouldRequireV2Signature(
               messageVersion: message.version,
@@ -430,13 +428,13 @@ class ProtocolMessageHandler implements IProtocolMessageHandler {
         _logger.fine(
           '✅ Signature verified (${message.useEphemeralSigning ? "ephemeral" : "real"})',
         );
-        if (message.version >= 2) {
-          isV2Authenticated = true;
+        if (message.version >= 2 && !message.useEphemeralSigning) {
+          isV2IdentityAuthenticated = true;
         }
       }
 
       _sendAck(messageId, fromNodeId);
-      if (message.version < 2 || isV2Authenticated) {
+      if (message.version < 2 || isV2IdentityAuthenticated) {
         _trackPeerVersionFloor(
           peerKey: versionPeerKey,
           messageVersion: message.version,
@@ -470,16 +468,11 @@ class ProtocolMessageHandler implements IProtocolMessageHandler {
 
   String _versionPeerKey({
     required String? signatureSenderKey,
-    required String? declaredSenderId,
-    required String transportSenderId,
   }) {
     if (signatureSenderKey != null && signatureSenderKey.isNotEmpty) {
       return signatureSenderKey;
     }
-    if (declaredSenderId != null && declaredSenderId.isNotEmpty) {
-      return declaredSenderId;
-    }
-    return transportSenderId;
+    return '';
   }
 
   bool _shouldRejectLegacyDowngrade({
@@ -763,7 +756,7 @@ class ProtocolMessageHandler implements IProtocolMessageHandler {
 
   Future<String?> _resolveSenderKeyForSignature(String? candidateKey) async {
     if (candidateKey == null || candidateKey.isEmpty) {
-      return candidateKey;
+      return null;
     }
     try {
       final contact = await _contactRepository.getContactByAnyId(candidateKey);
@@ -791,7 +784,7 @@ class ProtocolMessageHandler implements IProtocolMessageHandler {
         'Signature sender resolution failed for ${candidateKey.shortId(8)}: $e',
       );
     }
-    return candidateKey;
+    return null;
   }
 
   bool _isLegacyMode(CryptoMode mode) {


### PR DESCRIPTION
### Motivation
- Close a DoS vector where unauthenticated/unsigned or spoofed v2 messages could poison the downgrade-guard cache by using untrusted declared/transport sender identifiers as cache keys and thereby cause legitimate v1 messages to be rejected.

### Description
- Restrict the downgrade-guard peer key to the signature-resolved identity only and stop falling back to declared or transport IDs when computing the protocol-floor cache key in both inbound paths (`ProtocolMessageHandler` and `InboundTextProcessor`).
- Require identity-bound authentication before allowing a v2 protocol-floor upgrade by only marking v2 as "identity authenticated" when a verified, non-ephemeral signature is present, and skip floor upgrades for unauthenticated/ephemeral-only v2 messages.
- Harden signature-sender resolution so `_resolveSenderKeyForSignature` returns `null` when no contact-backed identity is resolved instead of trusting raw candidate IDs.
- Files changed: `lib/data/services/protocol_message_handler.dart`, `lib/data/services/inbound_text_processor.dart`.

### Testing
- Attempted to run the unit suites with `flutter test test/data/services/protocol_message_handler_test.dart test/data/services/inbound_text_processor_test.dart`, but the run failed in this environment because `flutter` was not available (`flutter: command not found`).
- Attempted to run `dart format` on the modified files, but the run failed because `dart` was not available in the environment (`dart: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69abf9bc77c48329b39c3af78441b570)