### PR TITLE
fix: stop trusting payload senderId for inbound attribution

### DIFF
--- a/lib/data/services/inbound_text_processor.dart
+++ b/lib/data/services/inbound_text_processor.dart
@@ -153,11 +153,11 @@ class InboundTextProcessor {
       return const InboundTextResult(content: null, shouldAck: false);
     }
 
-    final decryptKey = resolvedDeclaredSenderForDecrypt?.isNotEmpty == true
-        ? resolvedDeclaredSenderForDecrypt
-        : (resolvedSenderForDecrypt?.isNotEmpty == true
-              ? resolvedSenderForDecrypt
-              : resolvedOriginalSenderForDecrypt);
+    final decryptKey = resolvedSenderForDecrypt?.isNotEmpty == true
+        ? resolvedSenderForDecrypt
+        : (resolvedOriginalSenderForDecrypt?.isNotEmpty == true
+              ? resolvedOriginalSenderForDecrypt
+              : resolvedDeclaredSenderForDecrypt);
     String? decryptKeyUsed = decryptKey;
     var isV2Authenticated = protocolMessage.version < 2;
 
@@ -194,7 +194,11 @@ class InboundTextProcessor {
             return const InboundTextResult(content: null, shouldAck: false);
           }
           if (cryptoHeader.mode == CryptoMode.sealedV1) {
-            final sealedSenderId = declaredSenderId;
+            final sealedSenderId =
+                resolvedSenderForDecrypt ??
+                senderPublicKey ??
+                resolvedOriginalSenderForDecrypt ??
+                originalSender;
             final sealedRecipientId = protocolMessage.recipientId;
             if (sealedSenderId == null ||
                 sealedSenderId.isEmpty ||
@@ -380,10 +384,10 @@ class InboundTextProcessor {
         verifyingKey = protocolMessage.ephemeralSigningKey!;
       } else {
         final resolvedForSignature =
-            resolvedDeclaredSenderForSignature ??
             resolvedSenderForSignature ??
             senderPublicKey ??
-            resolvedOriginalSenderForSignature;
+            resolvedOriginalSenderForSignature ??
+            resolvedDeclaredSenderForSignature;
         if (resolvedForSignature == null) {
           _logger.severe('❌ Trusted message but no sender identity');
           return const InboundTextResult(
@@ -442,12 +446,12 @@ class InboundTextProcessor {
       shouldAck: true,
       resolvedSenderKey:
           decryptKeyUsed ??
-          resolvedDeclaredSenderForDecrypt ??
           resolvedSenderForDecrypt ??
           resolvedOriginalSenderForDecrypt ??
+          resolvedDeclaredSenderForDecrypt ??
           senderPublicKey ??
-          declaredSenderId ??
-          originalSender,
+          originalSender ??
+          declaredSenderId,
     );
   }
 

--- a/lib/data/services/protocol_message_handler.dart
+++ b/lib/data/services/protocol_message_handler.dart
@@ -226,21 +226,28 @@ class ProtocolMessageHandler implements IProtocolMessageHandler {
       final messageId = message.textMessageId!;
       final content = message.textContent!;
       final intendedRecipient = message.payload['intendedRecipient'] as String?;
-      final declaredSenderId =
-          message.senderId ??
-          (message.payload['originalSender'] as String?) ??
-          fromNodeId;
-      final resolvedDecryptSenderId = await _resolveSenderKeyForDecrypt(
-        declaredSenderId,
+      final originalSenderId = message.payload['originalSender'] as String?;
+      final declaredSenderId = message.senderId ?? originalSenderId;
+      final resolvedTransportSenderForDecrypt = await _resolveSenderKeyForDecrypt(
+        fromNodeId,
       );
-      final resolvedSignatureSenderKey = await _resolveSenderKeyForSignature(
-        declaredSenderId,
+      final resolvedOriginalSenderForDecrypt = await _resolveSenderKeyForDecrypt(
+        originalSenderId,
       );
-      final decryptionPeerId = (resolvedDecryptSenderId?.isNotEmpty ?? false)
-          ? resolvedDecryptSenderId!
-          : fromNodeId;
+      final resolvedTransportSenderForSignature =
+          await _resolveSenderKeyForSignature(fromNodeId);
+      final resolvedOriginalSenderForSignature =
+          await _resolveSenderKeyForSignature(originalSenderId);
+      final resolvedDeclaredSenderForSignature =
+          await _resolveSenderKeyForSignature(declaredSenderId);
+      final decryptionPeerId =
+          (resolvedTransportSenderForDecrypt?.isNotEmpty ?? false)
+          ? resolvedTransportSenderForDecrypt!
+          : ((resolvedOriginalSenderForDecrypt?.isNotEmpty ?? false)
+                ? resolvedOriginalSenderForDecrypt!
+                : fromNodeId);
       final versionPeerKey = _versionPeerKey(
-        signatureSenderKey: resolvedSignatureSenderKey,
+        signatureSenderKey: resolvedTransportSenderForSignature,
         declaredSenderId: declaredSenderId,
         transportSenderId: fromNodeId,
       );
@@ -303,10 +310,10 @@ class ProtocolMessageHandler implements IProtocolMessageHandler {
             }
             if (cryptoHeader.mode == CryptoMode.sealedV1) {
               final sealedSenderId =
-                  message.senderId ??
-                  (message.payload['originalSender'] as String?);
+                  resolvedTransportSenderForDecrypt ??
+                  fromNodeId;
               final recipientForSealed = message.recipientId;
-              if (sealedSenderId == null || sealedSenderId.isEmpty) {
+              if (sealedSenderId.isEmpty) {
                 _logger.severe(
                   '🔒 v2 sealed message missing sender binding: $messageId',
                 );
@@ -401,7 +408,11 @@ class ProtocolMessageHandler implements IProtocolMessageHandler {
             verifyingKey = message.ephemeralSigningKey!;
           }
         } else {
-          final signatureKey = resolvedSignatureSenderKey ?? declaredSenderId;
+          final signatureKey =
+              resolvedTransportSenderForSignature ??
+              resolvedOriginalSenderForSignature ??
+              resolvedDeclaredSenderForSignature ??
+              fromNodeId;
           if (signatureKey.isEmpty) {
             _logger.severe(
               '❌ v2 trusted signature missing sender verification key for message $messageId',

--- a/test/data/services/inbound_text_processor_test.dart
+++ b/test/data/services/inbound_text_processor_test.dart
@@ -34,7 +34,7 @@ void main() {
     });
 
     test(
-      'uses declared sender identity for v2 decrypt when transport sender is relay',
+      'uses transport sender identity for v2 decrypt when senderId differs',
       () async {
         final message = ProtocolMessage(
           type: ProtocolMessageType.textMessage,
@@ -57,12 +57,12 @@ void main() {
         expect(result.content, equals('typed:ciphertext'));
         expect(result.shouldAck, isTrue);
         expect(securityService.decryptMessageByTypeCalls, equals(1));
-        expect(securityService.lastDecryptPublicKey, equals('crypto-sender'));
+        expect(securityService.lastDecryptPublicKey, equals('relay-node'));
       },
     );
 
     test(
-      'uses sealed sender and recipient bindings from envelope over transport sender',
+      'uses transport sender binding for sealed v2 decrypt attribution',
       () async {
         final message = ProtocolMessage(
           type: ProtocolMessageType.textMessage,
@@ -92,7 +92,7 @@ void main() {
         expect(result.content, equals('sealed:ciphertext-base64'));
         expect(result.shouldAck, isTrue);
         expect(securityService.decryptSealedCalls, equals(1));
-        expect(securityService.lastSealedSenderId, equals('crypto-sender'));
+        expect(securityService.lastSealedSenderId, equals('relay-node'));
         expect(securityService.lastSealedRecipientId, equals('recipient-key'));
       },
     );

--- a/test/data/services/protocol_message_handler_test.dart
+++ b/test/data/services/protocol_message_handler_test.dart
@@ -393,7 +393,7 @@ void main() {
     });
 
     test(
-      'routes v2 decrypt by declared mode without fallback guessing',
+      'routes v2 decrypt by declared mode using transport sender identity',
       () async {
         final message = ProtocolMessage(
           type: ProtocolMessageType.textMessage,
@@ -418,7 +418,7 @@ void main() {
         expect(securityService.decryptMessageByTypeCalls, equals(1));
         expect(securityService.decryptMessageCalls, equals(0));
         expect(securityService.lastDecryptType, equals(EncryptionType.noise));
-        expect(securityService.lastDecryptPublicKey, equals('sender-key'));
+        expect(securityService.lastDecryptPublicKey, equals('relay-node'));
       },
     );
 
@@ -452,7 +452,7 @@ void main() {
       expect(result, equals('sealed:ciphertext-base64'));
       expect(securityService.decryptSealedCalls, equals(1));
       expect(securityService.decryptMessageByTypeCalls, equals(0));
-      expect(securityService.lastSealedSenderId, equals('sender-key'));
+      expect(securityService.lastSealedSenderId, equals('relay-node'));
       expect(securityService.lastSealedRecipientId, equals('recipient-key'));
     });
 


### PR DESCRIPTION
### Motivation
- Close a spoofing vulnerability where attacker-controlled `senderId` in v2 payloads could be used to misattribute and decrypt messages by being trusted ahead of the transport sender identity.
- Maintain the invariant that transport identity (the node-level sender) anchors decryption and UI attribution unless a verified signature or explicit binding proves otherwise.

### Description
- Change inbound decrypt key selection to prioritize the transport sender identity (`senderPublicKey` / `fromNodeId`) and only fall back to `originalSender` or `senderId` when necessary in `InboundTextProcessor`.
- For sealed-v2 messages, derive the sealed sender binding from the transport-resolved identity rather than the payload `senderId` before calling sealed decrypt APIs in `InboundTextProcessor` and `ProtocolMessageHandler`.
- Change signature verification resolver to prefer transport-derived verification keys and use declared/original sender as a last resort, preventing unauthenticated declared `senderId` from influencing verification.
- Update unit tests in `test/data/services/inbound_text_processor_test.dart` and `test/data/services/protocol_message_handler_test.dart` to assert transport-sender-based decrypt and sealed attribution behavior.

### Testing
- No full test suite was executed in this environment due to missing toolchain; `dart format` failed because `dart` is not installed and `flutter --version` also failed because `flutter` is not installed.
- Existing unit tests were updated to reflect the new transport-first behavior (files modified: `test/data/services/inbound_text_processor_test.dart` and `test/data/services/protocol_message_handler_test.dart`).
- Changes were committed locally with message `fix: stop trusting payload senderId for inbound attribution`.
- Manual code review and targeted test adjustments were performed to validate the logic changes, but automated `flutter test` could not be run here due to environment limitations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69abfadefdd0832986096b31a6cffc3e)