### PR TITLE
fix: enforce fail-closed encryption in selective backup/restore

### DIFF
--- a/lib/data/services/export_import/selective_backup_service.dart
+++ b/lib/data/services/export_import/selective_backup_service.dart
@@ -42,20 +42,18 @@ class SelectiveBackupService {
           ? sqlcipher.databaseFactory
           : sqflite_common.databaseFactory;
 
-      // Get encryption key for mobile platforms
-      String? encryptionKey;
-      if (Platform.isAndroid || Platform.isIOS) {
-        try {
-          encryptionKey = await DatabaseEncryption.getOrCreateEncryptionKey();
-          _logger.fine('Using encryption key for backup database');
-        } catch (e) {
-          _logger.warning('Failed to get encryption key for backup: $e');
-          // Continue without encryption for backup
-        }
+      final isMobilePlatform = Platform.isAndroid || Platform.isIOS;
+
+      // Enforce fail-closed behavior on mobile: backups must always be encrypted.
+      final encryptionKey = isMobilePlatform
+          ? await DatabaseEncryption.getOrCreateEncryptionKey()
+          : null;
+      if (isMobilePlatform) {
+        _logger.fine('Using encryption key for backup database');
       }
 
       // Open database with platform-specific options
-      final backupDb = Platform.isAndroid || Platform.isIOS
+      final backupDb = isMobilePlatform
           ? await factory.openDatabase(
               backupPath,
               options: sqlcipher.SqlCipherOpenDatabaseOptions(

--- a/lib/data/services/export_import/selective_restore_service.dart
+++ b/lib/data/services/export_import/selective_restore_service.dart
@@ -34,20 +34,18 @@ class SelectiveRestoreService {
           ? sqlcipher.databaseFactory
           : sqflite_common.databaseFactory;
 
-      // Get encryption key for mobile platforms
-      String? encryptionKey;
-      if (Platform.isAndroid || Platform.isIOS) {
-        try {
-          encryptionKey = await DatabaseEncryption.getOrCreateEncryptionKey();
-          _logger.fine('Using encryption key to open backup database');
-        } catch (e) {
-          _logger.warning('Failed to get encryption key for restore: $e');
-          // Try opening without encryption
-        }
+      final isMobilePlatform = Platform.isAndroid || Platform.isIOS;
+
+      // Enforce fail-closed behavior on mobile: restores require encrypted backups.
+      final encryptionKey = isMobilePlatform
+          ? await DatabaseEncryption.getOrCreateEncryptionKey()
+          : null;
+      if (isMobilePlatform) {
+        _logger.fine('Using encryption key to open backup database');
       }
 
       // Open database with platform-specific options
-      final backupDb = Platform.isAndroid || Platform.isIOS
+      final backupDb = isMobilePlatform
           ? await factory.openDatabase(
               backupPath,
               options: sqlcipher.SqlCipherOpenDatabaseOptions(


### PR DESCRIPTION
### Motivation
- The selective backup/restore paths were catching failures from `DatabaseEncryption.getOrCreateEncryptionKey()` and continuing with `password: null`, which allowed plaintext backups/restores on mobile when secure key retrieval failed. 
- This change enforces the intended fail-closed behavior so backups/restores on Android/iOS cannot proceed without a valid SQLCipher key.

### Description
- Removed the try/catch-and-continue logic and introduced `isMobilePlatform = Platform.isAndroid || Platform.isIOS` to centralize platform detection. 
- On mobile, the code now calls `await DatabaseEncryption.getOrCreateEncryptionKey()` directly and treats key retrieval as required (no fallback to `null`) in both `lib/data/services/export_import/selective_backup_service.dart` and `lib/data/services/export_import/selective_restore_service.dart`.
- Updated logging to reflect enforced key usage when `isMobilePlatform` is true. 
- The result is that mobile selective backups and restores will fail if the secure encryption key cannot be obtained, preventing plaintext export/restore.

### Testing
- Attempted to run `flutter test test/backup_restore_encryption_test.dart` but the `flutter` CLI was not available in this environment, so tests were not executed here. 
- Attempted to run `dart format` on the modified files but the `dart` binary was not available in this environment, so formatting was not executed here. 
- Local/unit test coverage: there are focused tests covering selective backup/restore flows (`test/backup_restore_encryption_test.dart` and `test/selective_export_import_test.dart`) and those should be run in a full Flutter-equipped environment to validate the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69abfb445de48329a5aba388505d386b)