### PR TITLE
fix: restore warning-level default logging for release/profile builds

### DIFF
--- a/lib/domain/utils/app_logger.dart
+++ b/lib/domain/utils/app_logger.dart
@@ -56,7 +56,7 @@ class AppLogger {
     if (configured != null) return configured;
 
     if (kReleaseMode || kProfileMode) {
-      return Level.INFO;
+      return Level.WARNING;
     }
     return Level.INFO;
   }


### PR DESCRIPTION
### Motivation
- Prevent INFO-level PII/metadata from being emitted in production by reverting the default release/profile log level to `WARNING` in `AppLogger`.

### Description
- Changed `AppLogger._resolveRootLevel()` in `lib/domain/utils/app_logger.dart` so that when `kReleaseMode` or `kProfileMode` is true it returns `Level.WARNING`, while preserving explicit overrides via the `PAKCONNECT_LOG_LEVEL` environment variable.

### Testing
- Attempted to run `flutter test test/domain/utils/app_logger_test.dart` but the execution environment lacks `flutter` so the test run failed with `bash: command not found: flutter`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69abfa49bb888329913eac64429a5496)