### PR TITLE
Close canonical PakConnect publication status

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -94,9 +94,9 @@ request.
 - GitHub redirects the old
   `AbubakarMahmood1/pak_connect_final` URL to the current public
   `AbubakarMahmood/pak_connect` repository; there is one remote project.
-- The compressed checkout is clean at `79b5c80`. Its five commits are
-  patch-equivalent to the canonical replay ending at `e70c7a8`; it has no
-  unique tracked semantics.
+- The compressed checkout was clean at `79b5c80`. Its five commits are
+  patch-equivalent to the canonical replay ending at `e70c7a8`; it had no
+  unique tracked semantics. The editable duplicate repository is now retired.
 - The canonical branch is a clean descendant of `origin/main`, seven commits
   ahead and zero behind at the start of this pass.
 - Every compressed ref is preserved in a verified complete Git bundle. The
@@ -106,10 +106,10 @@ request.
   `ABF2B337E41DDDF2127A0EBEF2C92E263B53FAE9E431D7DC6A75D347BA297AD3`.
 - Three clean third-party reference clones were moved intact to
   `%USERPROFILE%\repos\_references`.
-- Public `main` has a stale Flutter CI failure. The failure is a current-stable
-  Material/ListTile assertion in the message context-menu test; the workflow
-  also uses a moving Flutter channel, non-fatal analysis, and failure-skipped
-  artifact upload.
+- Public `main` began this pass with a stale Flutter CI failure, moving Flutter
+  channel, non-fatal analysis, and failure-skipped artifact upload. Those
+  defects are fixed and PR #71 passed the pinned Flutter 3.44.4 coverage job
+  plus Android and Actions CodeQL before merge.
 - The public README, bundled privacy policy, SRS, security, architecture and
   toolchain guidance now distinguish implemented behavior from device-gated,
   deferred and historical claims.
@@ -123,10 +123,11 @@ request.
 - The first Flutter 3.44 CI run exposed four `use_null_aware_elements`
   analyzer infos that local Flutter 3.41.5 did not report. Commit `9cccd01`
   applies the equivalent null-aware collection-element fixes; the prior
-  `fcb3013` build is superseded as a candidate baseline. Fresh exact-head CI
-  remains pending.
-- CI hardening is committed separately as `b32438d`; fresh GitHub Actions on
-  the eventual PR head remain the public authority.
+  `fcb3013` build is superseded as a candidate baseline. Exact-head CI passed.
+- CI hardening is committed separately as `b32438d`; the green PR #71 checks
+  on final head `f094474` are the public CI authority.
+- PR #71 merged through a normal merge commit as `f9b90c9`; local `main` and
+  `origin/main` were synchronized afterward.
 
 ## Approach
 
@@ -173,8 +174,9 @@ request.
   `9cccd01` device-test baseline plus APK/log hashes.
 - **Complete:** final public-claim/status reconciliation and exact two-device
   execution checklist.
-- **Pending:** fresh PR checks rerun on `9cccd01`, merge, and duplicate-tree
-  deletion.
+- **Complete:** final PR-head Flutter/CodeQL checks, normal PR #71 merge, local
+  and public `main` synchronization, stale remote/branch removal, and editable
+  duplicate-repository retirement.
 
 ---
 

--- a/docs/status/ENGINEERING_STATUS.md
+++ b/docs/status/ENGINEERING_STATUS.md
@@ -16,8 +16,10 @@ not yet a signed or hardware-validated release.
 ## Authority and preservation
 
 - Canonical remote: `AbubakarMahmood/pak_connect`.
-- The compressed working copy was checkpointed before reconciliation.
-- Active reconciliation branch: `codex/reconcile-pakconnect`.
+- The compressed working copy was checkpointed and archived before retirement;
+  the verified bundle, not a second checkout, is recovery authority.
+- PR #71 merged the reconciliation through normal merge commit `f9b90c9`.
+  Canonical local `main` and `origin/main` were synchronized after merge.
 - Verified code/build-input device-test baseline:
   `9cccd014c7bb93d0a3aab26aaf7674c3a5192dd3` (`9cccd01`). A
   documentation-only descendant is acceptable only when its build-input diff
@@ -27,9 +29,10 @@ not yet a signed or hardware-validated release.
   for the next device run.
 - Candidate `fcb3013` is also historical: Flutter 3.44 analysis required an
   equivalent null-aware syntax cleanup, which is included in `9cccd01`.
-- The reconciled history contains the mainline plus the preserved runtime,
+- The public mainline contains the preserved runtime,
   guidance, two-device-prep and Fable audit commits.
-- Do not use the compressed copy for new work; it is recovery evidence only.
+- The former compressed checkout is not an authorized worktree and must not be
+  recreated as a parallel working copy.
 
 ## Verification ledger
 

--- a/docs/status/READINESS_AUDIT.md
+++ b/docs/status/READINESS_AUDIT.md
@@ -19,9 +19,9 @@ radio behavior, mobile SQLCipher bytes at rest, OS background behavior,
 release signing and installation still require external evidence.
 
 The exact verified code/build-input tree is committed as
-`9cccd014c7bb93d0a3aab26aaf7674c3a5192dd3` (`9cccd01`) on
-`codex/reconcile-pakconnect`. A documentation-only descendant is acceptable
-only when its build-input diff from that commit is empty. The former
+`9cccd014c7bb93d0a3aab26aaf7674c3a5192dd3` (`9cccd01`) on public `main` via
+merged PR #71. A documentation-only descendant is acceptable only when its
+build-input diff from that commit is empty. The former
 `a5c2b08` baseline remains historical provenance. Candidate `fcb3013` is also
 historical because Flutter 3.44 analysis required an equivalent null-aware
 syntax cleanup now included in `9cccd01`.


### PR DESCRIPTION
## Summary

- mark the canonical publication/duplicate-repository plan complete after PR #71
- record the normal merge commit and synchronized `main`/`origin/main`
- replace stale active-branch/pending-CI language with the verified archive and retired-checkout authority

## Verification

- documentation-only descendant of device baseline `9cccd01`
- build-input diff across `lib test integration_test android ios assets pubspec.yaml pubspec.lock`: empty
- `git diff --check`: clean

No implementation, dependency, bundled asset, or device-baseline input changes.